### PR TITLE
Mobile Fixes, Removed no cost option in budget input 

### DIFF
--- a/nimbus-web/components/FormsElements/BudgetInput.tsx
+++ b/nimbus-web/components/FormsElements/BudgetInput.tsx
@@ -28,10 +28,6 @@ function valueMapper(value: number) {
 
 const marks = [
     {
-        value: 0,
-        label: "0",
-    },
-    {
         value: 1,
         label: "100",
     },
@@ -53,7 +49,7 @@ const BudgetInput = (props: any) => {
     const { currentValue } = React.useContext(ScrollContext);
     const { formData, setFormDataField } = React.useContext(PlanContext);
     const [value, setValue] = React.useState<number>(
-        formData.budget ? formData.budget : 0
+        formData.budget ? formData.budget : 1
     );
 
     const handleChange = (event: any, newValue: number | number[]) => {
@@ -71,7 +67,7 @@ const BudgetInput = (props: any) => {
     return (
         <>
             <ThemeProvider theme={nimbusTheme}>
-                <div className="flex mx-auto items-center h-full max-w-[15rem] w-full">
+                <div className="flex mx-auto items-center h-full max-w-[15rem] w-full md:scale-100 scale-[90%]">
                     <Slider
                         onChange={handleChange}
                         slots={{
@@ -81,16 +77,14 @@ const BudgetInput = (props: any) => {
                         value={value}
                         valueLabelDisplay="on"
                         step={1}
-                        min={0}
+                        min={1}
                         max={4}
                         color="secondary"
                         marks={marks}
                         valueLabelFormat={(value) => {
                             return (
                                 <div style={{ textAlign: "center" }}>
-                                    {value === 0
-                                        ? "no cost"
-                                        : value === 1
+                                    {value === 1
                                         ? "below 100 THB"
                                         : value === 2
                                         ? "below 500 THB"

--- a/nimbus-web/components/FormsElements/ConfirmForm.tsx
+++ b/nimbus-web/components/FormsElements/ConfirmForm.tsx
@@ -65,9 +65,9 @@ const ConfirmForm = () => {
         }
     }, [formData]);
     return (
-        <div className="m-auto flex pb-10 h-full mx-auto w-[90%] md:w-[75%] overflow-y-scroll flex flex-col items-center">
+        <div className="m-auto pb-10 h-full mx-auto w-[90%] md:w-[75%] overflow-y-scroll flex flex-col items-center">
             <div className="m-auto w-full">
-                <div className="text-center text-4xl text-neutral-700 font-extrabold px-0 pt-5">
+                <div className="text-center text-2xl sm:text-3xl md:text-4xl text-neutral-700 font-extrabold px-0 pt-5">
                     Confirm Inputs
                 </div>
                 <button

--- a/nimbus-web/components/MapPageComponents/PlanTab/Folders/PlanGraph.tsx
+++ b/nimbus-web/components/MapPageComponents/PlanTab/Folders/PlanGraph.tsx
@@ -101,7 +101,7 @@ const PlanGraph = (props: PlanGraphProps) => {
                                                         value: [true, index],
                                                     },
                                                 });
-                                                document.body.scrollTo({
+                                                window.scrollTo({
                                                     top: 0,
                                                     behavior: "smooth",
                                                 });
@@ -179,7 +179,7 @@ const PlanGraph = (props: PlanGraphProps) => {
                 <div className="flex w-full justify-center items-center my-4 mt-14">
                     <button
                         onClick={() => {
-                            document.body.scrollTo({
+                            window.scrollTo({
                                 top: 0,
                                 behavior: "smooth",
                             });

--- a/nimbus-web/components/Plan.tsx
+++ b/nimbus-web/components/Plan.tsx
@@ -136,8 +136,8 @@ const Plan = () => {
                                     ? window.innerHeight * 0.1
                                     : 0),
                         }}
-                        className="grid grid-flow-col md:rounded-xl shadow-lg bg-neutral-100
-                        m-auto max-w-[81rem] w-full md:w-[90%] min-w-[280px] overflow-hidden z-10"
+                        className="grid grid-flow-col md:rounded-xl shadow-lg bg-neutral-100 scrollbar-hide
+                        m-auto max-w-[81rem] w-full md:w-[90%] min-w-[250px] overflow-hidden z-10"
                     >
                         {!isConfirmActive ? (
                             <div


### PR DESCRIPTION
Main:
- Fixed scrolling not working in some devices by using window instead of document.body
- Adjusted plan style on smaller screens (supports to ~350 px width)
- Removed no cost option from budget input as an attempt to offset algorithm limitations (not enough places)